### PR TITLE
Use encoding for Buffer.byteLength only if `string` is a string

### DIFF
--- a/index.js
+++ b/index.js
@@ -381,7 +381,11 @@ exports.allocUnsafeSlow = function allocUnsafeSlow (size) {
 }
 
 exports.byteLength = function byteLength (string, encoding) {
-  return codecFor(encoding).byteLength(string)
+  if (typeof string === 'string') {
+    return codecFor(encoding).byteLength(string)
+  }
+
+  return string.byteLength
 }
 
 exports.compare = function compare (a, b) {

--- a/test/basic.js
+++ b/test/basic.js
@@ -19,6 +19,10 @@ test('allocUnsafeSlow', (t) => {
   t.is(Buffer.allocUnsafeSlow(42).byteLength, 42)
 })
 
+test('byteLength', (t) => {
+  t.is(Buffer.byteLength(Buffer.alloc(42)), 42)
+})
+
 test('compare', (t) => {
   t.is(Buffer.compare(Buffer.from([1, 2, 3]), Buffer.from([1, 2, 3])), 0)
   t.is(Buffer.compare(Buffer.from([1, 3, 2]), Buffer.from([1, 2, 3])), 1)


### PR DESCRIPTION
If `string` is not a string, then the `string.byteLength` is used instead. This fallback to `string.byteLength` is based on the [Node.js docs](https://nodejs.org/api/buffer.html#static-method-bufferbytelengthstring-encoding).