### PR TITLE
Export `BufferEncoding` type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -136,7 +136,7 @@ declare class Buffer extends Uint8Array {
 }
 
 declare namespace Buffer {
-  export { Buffer }
+  export { Buffer, BufferEncoding }
 
   export let poolSize: number
 


### PR DESCRIPTION
Needed for typing `encoding` at `bare-module-lexer`: https://github.com/holepunchto/bare-module-lexer/blob/cae252618ef4c4226cb209325a5640c3d3c88ef9/index.js#L3.