### PR TITLE
docs: document the public API as TSDoc (generated from type declarations)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,1282 @@ const combined = Buffer.concat([buffer, buffer])
 ## License
 
 Apache-2.0
+
+<!-- bare-refgen:api start -->
+
+## API
+
+### Buffer
+
+#### `new Buffer(arrayBuffer: ArrayBuffer, offset?: number, length?: number)`
+
+Create a `Buffer` viewing `arrayBuffer`, optionally starting at `offset` for `length` bytes.
+
+**Parameters**
+
+| Parameter     | Type          | Default | Description                                                                   |
+| ------------- | ------------- | ------- | ----------------------------------------------------------------------------- |
+| `arrayBuffer` | `ArrayBuffer` | —       | The `ArrayBuffer` to view.                                                    |
+| `offset?`     | `number`      | —       | Byte offset into `arrayBuffer` to start the view at; defaults to `0`.         |
+| `length?`     | `number`      | —       | Number of bytes to view from `offset`; defaults to the rest of `arrayBuffer`. |
+
+**Throws**
+
+- `RangeError` — thrown if the resulting length would exceed `Buffer.constants.MAX_LENGTH`.
+
+#### `Buffer.alloc(size: number, fill: string, encoding?: BufferEncoding): Buffer`
+
+Allocate a new, zero-filled `Buffer` of `size` bytes, optionally filled with `fill`.
+
+Overloads:
+
+```ts
+Buffer.alloc(size: number, fill: string, encoding?: BufferEncoding): Buffer
+Buffer.alloc(size: number, fill?: Buffer | number | boolean): Buffer
+```
+
+**Parameters**
+
+| Parameter   | Type             | Default | Description                                                                  |
+| ----------- | ---------------- | ------- | ---------------------------------------------------------------------------- |
+| `size`      | `number`         | —       | Number of bytes to allocate.                                                 |
+| `fill`      | `string`         | —       | Value to fill the buffer with — a string, `Buffer`, number byte, or boolean. |
+| `encoding?` | `BufferEncoding` | —       | Encoding used to interpret `fill` when it's a string; defaults to `'utf8'`.  |
+
+**Throws**
+
+- `RangeError` — thrown if `size` exceeds `Buffer.constants.MAX_LENGTH`.
+
+#### `Buffer.allocUnsafe(size: number): Buffer`
+
+Allocate a new `Buffer` of `size` bytes without zeroing its contents first.
+
+**Parameters**
+
+| Parameter | Type     | Default | Description                  |
+| --------- | -------- | ------- | ---------------------------- |
+| `size`    | `number` | —       | Number of bytes to allocate. |
+
+**Throws**
+
+- `RangeError` — thrown if `size` exceeds `Buffer.constants.MAX_LENGTH`.
+
+#### `Buffer.allocUnsafeSlow(size: number): Buffer`
+
+Allocate a new `Buffer` of `size` bytes without zeroing its contents first, bypassing the internal buffer pool.
+
+**Parameters**
+
+| Parameter | Type     | Default | Description                  |
+| --------- | -------- | ------- | ---------------------------- |
+| `size`    | `number` | —       | Number of bytes to allocate. |
+
+**Throws**
+
+- `RangeError` — thrown if `size` exceeds `Buffer.constants.MAX_LENGTH`.
+
+#### `Buffer.atob(data: unknown): string`
+
+Decode a base64-encoded string into a Latin-1 binary string.
+
+**Parameters**
+
+| Parameter | Type      | Default | Description                          |
+| --------- | --------- | ------- | ------------------------------------ |
+| `data`    | `unknown` | —       | The base64-encoded string to decode. |
+
+#### `Buffer.btoa(data: unknown): string`
+
+Encode a Latin-1 binary string into a base64 string.
+
+**Parameters**
+
+| Parameter | Type      | Default | Description                                                   |
+| --------- | --------- | ------- | ------------------------------------------------------------- |
+| `data`    | `unknown` | —       | The value to encode; non-strings are coerced with `String()`. |
+
+#### `Buffer.BufferEncoding`
+
+```ts
+type BufferEncoding =
+  | 'ascii'
+  | 'base64'
+  | 'binary'
+  | 'hex'
+  | 'latin1'
+  | 'ucs-2'
+  | 'ucs2'
+  | 'utf-16le'
+  | 'utf-8'
+  | 'utf16le'
+  | 'utf8'
+```
+
+The set of encodings supported by `Buffer` methods that convert between bytes and strings.
+
+#### `Buffer.byteLength`
+
+```ts
+Buffer.byteLength(string: ArrayBufferView | ArrayBufferLike | string, encoding?: BufferEncoding): number
+```
+
+Return the number of bytes `string` would occupy once encoded as `encoding`.
+
+**Parameters**
+
+| Parameter   | Type                                           | Default | Description                                                                                                                                     |
+| ----------- | ---------------------------------------------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| `string`    | `ArrayBufferView \| ArrayBufferLike \| string` | —       | The value whose encoded length to measure — a string, or an `ArrayBufferView`/`ArrayBufferLike` (whose own `byteLength` is returned unchanged). |
+| `encoding?` | `BufferEncoding`                               | —       | Encoding used to measure `string` when it's a string; defaults to `'utf8'`.                                                                     |
+
+**Throws**
+
+- `Error` — thrown if the encoding is not a recognized `BufferEncoding`.
+
+#### `Buffer.coerce(buffer: Buffer): Buffer`
+
+Return `buffer` unchanged if it is already a `Buffer`, otherwise wrap its underlying `ArrayBuffer` in a new `Buffer`.
+
+**Parameters**
+
+| Parameter | Type     | Default | Description                          |
+| --------- | -------- | ------- | ------------------------------------ |
+| `buffer`  | `Buffer` | —       | The value to coerce into a `Buffer`. |
+
+#### `Buffer.compare(a: Buffer, b: Buffer): number`
+
+Compare two buffers' contents lexicographically, returning -1, 0, or 1 for sort ordering.
+
+**Parameters**
+
+| Parameter | Type     | Default | Description                   |
+| --------- | -------- | ------- | ----------------------------- |
+| `a`       | `Buffer` | —       | The first buffer to compare.  |
+| `b`       | `Buffer` | —       | The second buffer to compare. |
+
+#### `Buffer.concat(buffers: Buffer[], length?: number): Buffer`
+
+Concatenate `buffers` into a single new `Buffer`, optionally truncated or zero-padded to `length`.
+
+**Parameters**
+
+| Parameter | Type       | Default | Description                                                                 |
+| --------- | ---------- | ------- | --------------------------------------------------------------------------- |
+| `buffers` | `Buffer[]` | —       | The buffers to concatenate, in order.                                       |
+| `length?` | `number`   | —       | Total byte length of the result; defaults to the sum of `buffers`' lengths. |
+
+#### `Buffer.constants: { MAX_LENGTH: number; MAX_STRING_LENGTH: number }`
+
+Limits for buffers and strings: `MAX_LENGTH` (largest possible `Buffer`) and `MAX_STRING_LENGTH` (largest possible string).
+
+#### `Buffer.copyBytesFrom(view: ArrayBufferLike, offset?: number, length?: number): Buffer`
+
+Copy the bytes of `view`, starting at `offset` for `length` elements, into a new `Buffer`.
+
+**Parameters**
+
+| Parameter | Type              | Default | Description                                                           |
+| --------- | ----------------- | ------- | --------------------------------------------------------------------- |
+| `view`    | `ArrayBufferLike` | —       | The typed array (or other `ArrayBufferLike` view) to copy bytes from. |
+| `offset?` | `number`          | —       | Index of the first element to copy; defaults to `0`.                  |
+| `length?` | `number`          | —       | Number of elements to copy; defaults to the rest of `view`.           |
+
+**Throws**
+
+- `RangeError` — thrown if `offset + length` exceeds `view.length`.
+
+#### `Buffer.from(data: Iterable<number>): Buffer`
+
+Create a new `Buffer` from an array, array-like, string, or `ArrayBuffer`.
+
+Overloads:
+
+```ts
+Buffer.from(data: Iterable<number>): Buffer
+Buffer.from(data: ArrayLike<number>): Buffer
+Buffer.from(string: string, encoding?: BufferEncoding): Buffer
+Buffer.from(arrayBuffer: ArrayBufferLike, offset?: number, length?: number): Buffer
+```
+
+**Parameters**
+
+| Parameter | Type               | Default | Description                                                                            |
+| --------- | ------------------ | ------- | -------------------------------------------------------------------------------------- |
+| `data`    | `Iterable<number>` | —       | The array, array-like, string, buffer, or `ArrayBuffer` to create a new `Buffer` from. |
+
+**Throws**
+
+- `Error` — thrown if the encoding is not a recognized `BufferEncoding`.
+
+#### `Buffer.isAscii(buffer: Buffer): boolean`
+
+Check whether `buffer` contains only valid ASCII-encoded data.
+
+**Parameters**
+
+| Parameter | Type     | Default | Description          |
+| --------- | -------- | ------- | -------------------- |
+| `buffer`  | `Buffer` | —       | The buffer to check. |
+
+#### `Buffer.isASCII(buffer: Buffer): boolean`
+
+Check whether `buffer` contains only valid ASCII-encoded data.
+
+**Parameters**
+
+| Parameter | Type     | Default | Description          |
+| --------- | -------- | ------- | -------------------- |
+| `buffer`  | `Buffer` | —       | The buffer to check. |
+
+#### `Buffer.isBuffer(value: unknown): value is Buffer`
+
+Check whether `value` is a `Buffer`.
+
+**Parameters**
+
+| Parameter | Type      | Default | Description         |
+| --------- | --------- | ------- | ------------------- |
+| `value`   | `unknown` | —       | The value to check. |
+
+#### `Buffer.isEncoding(encoding: string): encoding is BufferEncoding`
+
+Check whether `encoding` is a supported `BufferEncoding`.
+
+**Parameters**
+
+| Parameter  | Type     | Default | Description                 |
+| ---------- | -------- | ------- | --------------------------- |
+| `encoding` | `string` | —       | The encoding name to check. |
+
+#### `Buffer.isUtf8(buffer: Buffer): boolean`
+
+Check whether `buffer` contains only valid UTF-8-encoded data.
+
+**Parameters**
+
+| Parameter | Type     | Default | Description          |
+| --------- | -------- | ------- | -------------------- |
+| `buffer`  | `Buffer` | —       | The buffer to check. |
+
+#### `Buffer.isUTF8(buffer: Buffer): boolean`
+
+Check whether `buffer` contains only valid UTF-8-encoded data.
+
+**Parameters**
+
+| Parameter | Type     | Default | Description          |
+| --------- | -------- | ------- | -------------------- |
+| `buffer`  | `Buffer` | —       | The buffer to check. |
+
+#### `Buffer.poolSize: number`
+
+The size, in bytes, of the internal buffer pool used to satisfy small allocations.
+
+#### `Buffer.transcode(buffer: Buffer, from: BufferEncoding, to: BufferEncoding): Buffer`
+
+Re-encode `buffer` from one encoding to another, returning a new `Buffer`.
+
+**Parameters**
+
+| Parameter | Type             | Default | Description                            |
+| --------- | ---------------- | ------- | -------------------------------------- |
+| `buffer`  | `Buffer`         | —       | The buffer to re-encode.               |
+| `from`    | `BufferEncoding` | —       | The encoding `buffer` is currently in. |
+| `to`      | `BufferEncoding` | —       | The encoding to convert to.            |
+
+**Throws**
+
+- `Error` — thrown if the encoding is not a recognized `BufferEncoding`.
+
+#### `compare`
+
+```ts
+compare(target: Buffer, targetStart?: number, targetEnd?: number, sourceStart?: number, sourceEnd?: number): number
+```
+
+Compare two buffers' contents lexicographically, returning -1, 0, or 1 for sort ordering.
+
+**Parameters**
+
+| Parameter      | Type     | Default | Description                                                                                |
+| -------------- | -------- | ------- | ------------------------------------------------------------------------------------------ |
+| `target`       | `Buffer` | —       | The buffer to compare against.                                                             |
+| `targetStart?` | `number` | —       | Offset within `target` to start comparing from; defaults to `0`.                           |
+| `targetEnd?`   | `number` | —       | Offset within `target` (exclusive) to stop comparing at; defaults to `target.byteLength`.  |
+| `sourceStart?` | `number` | —       | Offset within this buffer to start comparing from; defaults to `0`.                        |
+| `sourceEnd?`   | `number` | —       | Offset within this buffer (exclusive) to stop comparing at; defaults to `this.byteLength`. |
+
+#### `copy(target: Buffer, targetStart?: number, sourceStart?: number, sourceEnd?: number): number`
+
+Copy bytes from this buffer into `target`, returning the number of bytes copied.
+
+**Parameters**
+
+| Parameter      | Type     | Default | Description                                                                              |
+| -------------- | -------- | ------- | ---------------------------------------------------------------------------------------- |
+| `target`       | `Buffer` | —       | The buffer to copy into.                                                                 |
+| `targetStart?` | `number` | —       | Offset within `target` to start writing at; defaults to `0`.                             |
+| `sourceStart?` | `number` | —       | Offset within this buffer to start copying from; defaults to `0`.                        |
+| `sourceEnd?`   | `number` | —       | Offset within this buffer (exclusive) to stop copying at; defaults to `this.byteLength`. |
+
+#### `equals(target: Buffer): boolean`
+
+Check whether this buffer and `target` have identical contents.
+
+**Parameters**
+
+| Parameter | Type     | Default | Description                                           |
+| --------- | -------- | ------- | ----------------------------------------------------- |
+| `target`  | `Buffer` | —       | The buffer to compare this buffer's contents against. |
+
+#### `fill(value: string, encoding?: BufferEncoding): this`
+
+Fill this buffer with `value`, repeating as needed, and return it.
+
+Overloads:
+
+```ts
+fill(value: string, encoding?: BufferEncoding): this
+fill(value: string, offset?: number, encoding?: BufferEncoding): this
+fill(value: string, offset?: number, end?: number, encoding?: BufferEncoding): this
+fill(value: Buffer | number | boolean, offset?: number, end?: number): this
+```
+
+**Parameters**
+
+| Parameter   | Type             | Default | Description                                                                                       |
+| ----------- | ---------------- | ------- | ------------------------------------------------------------------------------------------------- |
+| `value`     | `string`         | —       | The value to fill with — a string (repeated across the range), or a `Buffer`/number/boolean byte. |
+| `encoding?` | `BufferEncoding` | —       | Encoding used to interpret `value` when it's a string; defaults to `'utf8'`.                      |
+
+**Throws**
+
+- `Error` — thrown if the encoding is not a recognized `BufferEncoding`.
+
+#### `includes(value: string, encoding?: BufferEncoding): boolean`
+
+Check whether this buffer contains `value`.
+
+Overloads:
+
+```ts
+includes(value: string, encoding?: BufferEncoding): boolean
+includes(value: string, offset?: number, encoding?: BufferEncoding): boolean
+includes(value: Buffer | number | boolean, offset?: number): boolean
+```
+
+**Parameters**
+
+| Parameter   | Type             | Default | Description                                                                  |
+| ----------- | ---------------- | ------- | ---------------------------------------------------------------------------- |
+| `value`     | `string`         | —       | The value to search for — a string, `Buffer`, number byte, or boolean.       |
+| `encoding?` | `BufferEncoding` | —       | Encoding used to interpret `value` when it's a string; defaults to `'utf8'`. |
+
+**Throws**
+
+- `Error` — thrown if the encoding is not a recognized `BufferEncoding`.
+
+#### `indexOf(value: string, encoding?: BufferEncoding): number`
+
+Return the first index at which `value` occurs in this buffer, or `-1` if not found.
+
+Overloads:
+
+```ts
+indexOf(value: string, encoding?: BufferEncoding): number
+indexOf(value: string, offset?: number, encoding?: BufferEncoding): number
+indexOf(value: Buffer | number | boolean, offset?: number): number
+```
+
+**Parameters**
+
+| Parameter   | Type             | Default | Description                                                                  |
+| ----------- | ---------------- | ------- | ---------------------------------------------------------------------------- |
+| `value`     | `string`         | —       | The value to search for — a string, `Buffer`, number byte, or boolean.       |
+| `encoding?` | `BufferEncoding` | —       | Encoding used to interpret `value` when it's a string; defaults to `'utf8'`. |
+
+**Throws**
+
+- `Error` — thrown if the encoding is not a recognized `BufferEncoding`.
+
+#### `lastIndexOf(value: string, encoding?: BufferEncoding): number`
+
+Return the last index at which `value` occurs in this buffer, or `-1` if not found.
+
+Overloads:
+
+```ts
+lastIndexOf(value: string, encoding?: BufferEncoding): number
+lastIndexOf(value: string, offset?: number, encoding?: BufferEncoding): number
+lastIndexOf(value: Buffer | number | boolean, offset?: number): number
+```
+
+**Parameters**
+
+| Parameter   | Type             | Default | Description                                                                  |
+| ----------- | ---------------- | ------- | ---------------------------------------------------------------------------- |
+| `value`     | `string`         | —       | The value to search for — a string, `Buffer`, number byte, or boolean.       |
+| `encoding?` | `BufferEncoding` | —       | Encoding used to interpret `value` when it's a string; defaults to `'utf8'`. |
+
+**Throws**
+
+- `Error` — thrown if the encoding is not a recognized `BufferEncoding`.
+
+#### `readBigInt64BE(offset?: number): bigint`
+
+Read a signed 64-bit big-endian integer at `offset`.
+
+**Parameters**
+
+| Parameter | Type     | Default | Description                                |
+| --------- | -------- | ------- | ------------------------------------------ |
+| `offset?` | `number` | —       | Byte offset to read from; defaults to `0`. |
+
+#### `readBigInt64LE(offset?: number): bigint`
+
+Read a signed 64-bit little-endian integer at `offset`.
+
+**Parameters**
+
+| Parameter | Type     | Default | Description                                |
+| --------- | -------- | ------- | ------------------------------------------ |
+| `offset?` | `number` | —       | Byte offset to read from; defaults to `0`. |
+
+#### `readBigUint64BE(offset?: number): bigint`
+
+Read an unsigned 64-bit big-endian integer at `offset`.
+
+**Parameters**
+
+| Parameter | Type     | Default | Description                                |
+| --------- | -------- | ------- | ------------------------------------------ |
+| `offset?` | `number` | —       | Byte offset to read from; defaults to `0`. |
+
+#### `readBigUInt64BE(offset?: number): bigint`
+
+Read an unsigned 64-bit big-endian integer at `offset`.
+
+**Parameters**
+
+| Parameter | Type     | Default | Description                                |
+| --------- | -------- | ------- | ------------------------------------------ |
+| `offset?` | `number` | —       | Byte offset to read from; defaults to `0`. |
+
+#### `readBigUint64LE(offset?: number): bigint`
+
+Read an unsigned 64-bit little-endian integer at `offset`.
+
+**Parameters**
+
+| Parameter | Type     | Default | Description                                |
+| --------- | -------- | ------- | ------------------------------------------ |
+| `offset?` | `number` | —       | Byte offset to read from; defaults to `0`. |
+
+#### `readBigUInt64LE(offset?: number): bigint`
+
+Read an unsigned 64-bit little-endian integer at `offset`.
+
+**Parameters**
+
+| Parameter | Type     | Default | Description                                |
+| --------- | -------- | ------- | ------------------------------------------ |
+| `offset?` | `number` | —       | Byte offset to read from; defaults to `0`. |
+
+#### `readDoubleBE(offset?: number): number`
+
+Read a 64-bit big-endian double at `offset`.
+
+**Parameters**
+
+| Parameter | Type     | Default | Description                                |
+| --------- | -------- | ------- | ------------------------------------------ |
+| `offset?` | `number` | —       | Byte offset to read from; defaults to `0`. |
+
+#### `readDoubleLE(offset?: number): number`
+
+Read a 64-bit little-endian double at `offset`.
+
+**Parameters**
+
+| Parameter | Type     | Default | Description                                |
+| --------- | -------- | ------- | ------------------------------------------ |
+| `offset?` | `number` | —       | Byte offset to read from; defaults to `0`. |
+
+#### `readFloatBE(offset?: number): number`
+
+Read a 32-bit big-endian float at `offset`.
+
+**Parameters**
+
+| Parameter | Type     | Default | Description                                |
+| --------- | -------- | ------- | ------------------------------------------ |
+| `offset?` | `number` | —       | Byte offset to read from; defaults to `0`. |
+
+#### `readFloatLE(offset?: number): number`
+
+Read a 32-bit little-endian float at `offset`.
+
+**Parameters**
+
+| Parameter | Type     | Default | Description                                |
+| --------- | -------- | ------- | ------------------------------------------ |
+| `offset?` | `number` | —       | Byte offset to read from; defaults to `0`. |
+
+#### `readInt16BE(offset?: number): number`
+
+Read a signed 16-bit big-endian integer at `offset`.
+
+**Parameters**
+
+| Parameter | Type     | Default | Description                                |
+| --------- | -------- | ------- | ------------------------------------------ |
+| `offset?` | `number` | —       | Byte offset to read from; defaults to `0`. |
+
+#### `readInt16LE(offset?: number): number`
+
+Read a signed 16-bit little-endian integer at `offset`.
+
+**Parameters**
+
+| Parameter | Type     | Default | Description                                |
+| --------- | -------- | ------- | ------------------------------------------ |
+| `offset?` | `number` | —       | Byte offset to read from; defaults to `0`. |
+
+#### `readInt32BE(offset?: number): number`
+
+Read a signed 32-bit big-endian integer at `offset`.
+
+**Parameters**
+
+| Parameter | Type     | Default | Description                                |
+| --------- | -------- | ------- | ------------------------------------------ |
+| `offset?` | `number` | —       | Byte offset to read from; defaults to `0`. |
+
+#### `readInt32LE(offset?: number): number`
+
+Read a signed 32-bit little-endian integer at `offset`.
+
+**Parameters**
+
+| Parameter | Type     | Default | Description                                |
+| --------- | -------- | ------- | ------------------------------------------ |
+| `offset?` | `number` | —       | Byte offset to read from; defaults to `0`. |
+
+#### `readInt8(offset?: number): number`
+
+Read a signed 8-bit integer at `offset`.
+
+**Parameters**
+
+| Parameter | Type     | Default | Description                                |
+| --------- | -------- | ------- | ------------------------------------------ |
+| `offset?` | `number` | —       | Byte offset to read from; defaults to `0`. |
+
+#### `readIntBE(offset: number, byteLength: number): number`
+
+Read a signed, big-endian, `byteLength`-byte integer at `offset`.
+
+**Parameters**
+
+| Parameter    | Type     | Default | Description                               |
+| ------------ | -------- | ------- | ----------------------------------------- |
+| `offset`     | `number` | —       | Byte offset to read from.                 |
+| `byteLength` | `number` | —       | Number of bytes to read, from `1` to `6`. |
+
+**Throws**
+
+- `RangeError` — thrown if `byteLength` is not between `1` and `6`.
+
+#### `readIntLE(offset: number, byteLength: number): number`
+
+Read a signed, little-endian, `byteLength`-byte integer at `offset`.
+
+**Parameters**
+
+| Parameter    | Type     | Default | Description                               |
+| ------------ | -------- | ------- | ----------------------------------------- |
+| `offset`     | `number` | —       | Byte offset to read from.                 |
+| `byteLength` | `number` | —       | Number of bytes to read, from `1` to `6`. |
+
+**Throws**
+
+- `RangeError` — thrown if `byteLength` is not between `1` and `6`.
+
+#### `readUint16BE(offset?: number): number`
+
+Read an unsigned 16-bit big-endian integer at `offset`.
+
+**Parameters**
+
+| Parameter | Type     | Default | Description                                |
+| --------- | -------- | ------- | ------------------------------------------ |
+| `offset?` | `number` | —       | Byte offset to read from; defaults to `0`. |
+
+#### `readUInt16BE(offset?: number): number`
+
+Read an unsigned 16-bit big-endian integer at `offset`.
+
+**Parameters**
+
+| Parameter | Type     | Default | Description                                |
+| --------- | -------- | ------- | ------------------------------------------ |
+| `offset?` | `number` | —       | Byte offset to read from; defaults to `0`. |
+
+#### `readUint16LE(offset?: number): number`
+
+Read an unsigned 16-bit little-endian integer at `offset`.
+
+**Parameters**
+
+| Parameter | Type     | Default | Description                                |
+| --------- | -------- | ------- | ------------------------------------------ |
+| `offset?` | `number` | —       | Byte offset to read from; defaults to `0`. |
+
+#### `readUInt16LE(offset?: number): number`
+
+Read an unsigned 16-bit little-endian integer at `offset`.
+
+**Parameters**
+
+| Parameter | Type     | Default | Description                                |
+| --------- | -------- | ------- | ------------------------------------------ |
+| `offset?` | `number` | —       | Byte offset to read from; defaults to `0`. |
+
+#### `readUint32BE(offset?: number): number`
+
+Read an unsigned 32-bit big-endian integer at `offset`.
+
+**Parameters**
+
+| Parameter | Type     | Default | Description                                |
+| --------- | -------- | ------- | ------------------------------------------ |
+| `offset?` | `number` | —       | Byte offset to read from; defaults to `0`. |
+
+#### `readUInt32BE(offset?: number): number`
+
+Read an unsigned 32-bit big-endian integer at `offset`.
+
+**Parameters**
+
+| Parameter | Type     | Default | Description                                |
+| --------- | -------- | ------- | ------------------------------------------ |
+| `offset?` | `number` | —       | Byte offset to read from; defaults to `0`. |
+
+#### `readUint32LE(offset?: number): number`
+
+Read an unsigned 32-bit little-endian integer at `offset`.
+
+**Parameters**
+
+| Parameter | Type     | Default | Description                                |
+| --------- | -------- | ------- | ------------------------------------------ |
+| `offset?` | `number` | —       | Byte offset to read from; defaults to `0`. |
+
+#### `readUInt32LE(offset?: number): number`
+
+Read an unsigned 32-bit little-endian integer at `offset`.
+
+**Parameters**
+
+| Parameter | Type     | Default | Description                                |
+| --------- | -------- | ------- | ------------------------------------------ |
+| `offset?` | `number` | —       | Byte offset to read from; defaults to `0`. |
+
+#### `readUint8(offset?: number): number`
+
+Read an unsigned 8-bit integer at `offset`.
+
+**Parameters**
+
+| Parameter | Type     | Default | Description                                |
+| --------- | -------- | ------- | ------------------------------------------ |
+| `offset?` | `number` | —       | Byte offset to read from; defaults to `0`. |
+
+#### `readUInt8(offset?: number): number`
+
+Read an unsigned 8-bit integer at `offset`.
+
+**Parameters**
+
+| Parameter | Type     | Default | Description                                |
+| --------- | -------- | ------- | ------------------------------------------ |
+| `offset?` | `number` | —       | Byte offset to read from; defaults to `0`. |
+
+#### `readUintBE(offset: number, byteLength: number): number`
+
+Read an unsigned, big-endian, `byteLength`-byte integer at `offset`.
+
+**Parameters**
+
+| Parameter    | Type     | Default | Description                               |
+| ------------ | -------- | ------- | ----------------------------------------- |
+| `offset`     | `number` | —       | Byte offset to read from.                 |
+| `byteLength` | `number` | —       | Number of bytes to read, from `1` to `6`. |
+
+**Throws**
+
+- `RangeError` — thrown if `byteLength` is not between `1` and `6`.
+
+#### `readUIntBE(offset: number, byteLength: number): number`
+
+Read an unsigned, big-endian, `byteLength`-byte integer at `offset`.
+
+**Parameters**
+
+| Parameter    | Type     | Default | Description                               |
+| ------------ | -------- | ------- | ----------------------------------------- |
+| `offset`     | `number` | —       | Byte offset to read from.                 |
+| `byteLength` | `number` | —       | Number of bytes to read, from `1` to `6`. |
+
+**Throws**
+
+- `RangeError` — thrown if `byteLength` is not between `1` and `6`.
+
+#### `readUintLE(offset: number, byteLength: number): number`
+
+Read an unsigned, little-endian, `byteLength`-byte integer at `offset`.
+
+**Parameters**
+
+| Parameter    | Type     | Default | Description                               |
+| ------------ | -------- | ------- | ----------------------------------------- |
+| `offset`     | `number` | —       | Byte offset to read from.                 |
+| `byteLength` | `number` | —       | Number of bytes to read, from `1` to `6`. |
+
+**Throws**
+
+- `RangeError` — thrown if `byteLength` is not between `1` and `6`.
+
+#### `readUIntLE(offset: number, byteLength: number): number`
+
+Read an unsigned, little-endian, `byteLength`-byte integer at `offset`.
+
+**Parameters**
+
+| Parameter    | Type     | Default | Description                               |
+| ------------ | -------- | ------- | ----------------------------------------- |
+| `offset`     | `number` | —       | Byte offset to read from.                 |
+| `byteLength` | `number` | —       | Number of bytes to read, from `1` to `6`. |
+
+**Throws**
+
+- `RangeError` — thrown if `byteLength` is not between `1` and `6`.
+
+#### `swap16(): this`
+
+Swap the byte order of each 16-bit group in this buffer in place, and return it.
+
+**Throws**
+
+- `RangeError` — thrown if the buffer's length is not a multiple of 2 bytes.
+
+#### `swap32(): this`
+
+Swap the byte order of each 32-bit group in this buffer in place, and return it.
+
+**Throws**
+
+- `RangeError` — thrown if the buffer's length is not a multiple of 4 bytes.
+
+#### `swap64(): this`
+
+Swap the byte order of each 64-bit group in this buffer in place, and return it.
+
+**Throws**
+
+- `RangeError` — thrown if the buffer's length is not a multiple of 8 bytes.
+
+#### `toJSON(): number[]`
+
+Return an array of this buffer's bytes, used when the buffer is passed to `JSON.stringify()`.
+
+#### `toString(encoding?: BufferEncoding, start?: number, end?: number): string`
+
+Decode this buffer (or a slice of it) to a string using `encoding`.
+
+**Parameters**
+
+| Parameter   | Type             | Default | Description                                                                 |
+| ----------- | ---------------- | ------- | --------------------------------------------------------------------------- |
+| `encoding?` | `BufferEncoding` | —       | Encoding used to decode the bytes; defaults to `'utf8'`.                    |
+| `start?`    | `number`         | —       | Byte offset to start decoding from; defaults to `0`.                        |
+| `end?`      | `number`         | —       | Byte offset (exclusive) to stop decoding at; defaults to `this.byteLength`. |
+
+**Throws**
+
+- `Error` — thrown if the encoding is not a recognized `BufferEncoding`.
+
+#### `write(string: string, encoding?: BufferEncoding): number`
+
+Write `string` into this buffer using `encoding`, returning the number of bytes written.
+
+Overloads:
+
+```ts
+write(string: string, encoding?: BufferEncoding): number
+write(string: string, offset?: number, encoding?: BufferEncoding): number
+write(string: string, offset?: number, length?: number, encoding?: BufferEncoding): number
+```
+
+**Parameters**
+
+| Parameter   | Type             | Default | Description                                             |
+| ----------- | ---------------- | ------- | ------------------------------------------------------- |
+| `string`    | `string`         | —       | The string to write.                                    |
+| `encoding?` | `BufferEncoding` | —       | Encoding used to encode `string`; defaults to `'utf8'`. |
+
+**Throws**
+
+- `Error` — thrown if the encoding is not a recognized `BufferEncoding`.
+
+#### `writeBigInt64BE(value: bigint, offset?: number): number`
+
+Write a signed 64-bit big-endian integer at `offset`.
+
+**Parameters**
+
+| Parameter | Type     | Default | Description                               |
+| --------- | -------- | ------- | ----------------------------------------- |
+| `value`   | `bigint` | —       | The signed `bigint` to write.             |
+| `offset?` | `number` | —       | Byte offset to write to; defaults to `0`. |
+
+**Returns** `number` — `offset + 8`, the offset immediately following the written value.
+
+#### `writeBigInt64LE(value: bigint, offset?: number): number`
+
+Write a signed 64-bit little-endian integer at `offset`.
+
+**Parameters**
+
+| Parameter | Type     | Default | Description                               |
+| --------- | -------- | ------- | ----------------------------------------- |
+| `value`   | `bigint` | —       | The signed `bigint` to write.             |
+| `offset?` | `number` | —       | Byte offset to write to; defaults to `0`. |
+
+**Returns** `number` — `offset + 8`, the offset immediately following the written value.
+
+#### `writeBigUint64BE(value: bigint, offset?: number): number`
+
+Write an unsigned 64-bit big-endian integer at `offset`.
+
+**Parameters**
+
+| Parameter | Type     | Default | Description                               |
+| --------- | -------- | ------- | ----------------------------------------- |
+| `value`   | `bigint` | —       | The unsigned `bigint` to write.           |
+| `offset?` | `number` | —       | Byte offset to write to; defaults to `0`. |
+
+**Returns** `number` — `offset + 8`, the offset immediately following the written value.
+
+#### `writeBigUInt64BE(value: bigint, offset?: number): number`
+
+Write an unsigned 64-bit big-endian integer at `offset`.
+
+**Parameters**
+
+| Parameter | Type     | Default | Description                               |
+| --------- | -------- | ------- | ----------------------------------------- |
+| `value`   | `bigint` | —       | The unsigned `bigint` to write.           |
+| `offset?` | `number` | —       | Byte offset to write to; defaults to `0`. |
+
+**Returns** `number` — `offset + 8`, the offset immediately following the written value.
+
+#### `writeBigUint64LE(value: bigint, offset?: number): number`
+
+Write an unsigned 64-bit little-endian integer at `offset`.
+
+**Parameters**
+
+| Parameter | Type     | Default | Description                               |
+| --------- | -------- | ------- | ----------------------------------------- |
+| `value`   | `bigint` | —       | The unsigned `bigint` to write.           |
+| `offset?` | `number` | —       | Byte offset to write to; defaults to `0`. |
+
+**Returns** `number` — `offset + 8`, the offset immediately following the written value.
+
+#### `writeBigUInt64LE(value: bigint, offset?: number): number`
+
+Write an unsigned 64-bit little-endian integer at `offset`.
+
+**Parameters**
+
+| Parameter | Type     | Default | Description                               |
+| --------- | -------- | ------- | ----------------------------------------- |
+| `value`   | `bigint` | —       | The unsigned `bigint` to write.           |
+| `offset?` | `number` | —       | Byte offset to write to; defaults to `0`. |
+
+**Returns** `number` — `offset + 8`, the offset immediately following the written value.
+
+#### `writeDoubleBE(value: number, offset?: number): number`
+
+Write a 64-bit big-endian double at `offset`.
+
+**Parameters**
+
+| Parameter | Type     | Default | Description                               |
+| --------- | -------- | ------- | ----------------------------------------- |
+| `value`   | `number` | —       | The double-precision number to write.     |
+| `offset?` | `number` | —       | Byte offset to write to; defaults to `0`. |
+
+**Returns** `number` — `offset + 8`, the offset immediately following the written value.
+
+#### `writeDoubleLE(value: number, offset?: number): number`
+
+Write a 64-bit little-endian double at `offset`.
+
+**Parameters**
+
+| Parameter | Type     | Default | Description                               |
+| --------- | -------- | ------- | ----------------------------------------- |
+| `value`   | `number` | —       | The double-precision number to write.     |
+| `offset?` | `number` | —       | Byte offset to write to; defaults to `0`. |
+
+**Returns** `number` — `offset + 8`, the offset immediately following the written value.
+
+#### `writeFloatBE(value: number, offset?: number): number`
+
+Write a 32-bit big-endian float at `offset`.
+
+**Parameters**
+
+| Parameter | Type     | Default | Description                               |
+| --------- | -------- | ------- | ----------------------------------------- |
+| `value`   | `number` | —       | The single-precision number to write.     |
+| `offset?` | `number` | —       | Byte offset to write to; defaults to `0`. |
+
+**Returns** `number` — `offset + 4`, the offset immediately following the written value.
+
+#### `writeFloatLE(value: number, offset?: number): number`
+
+Write a 32-bit little-endian float at `offset`.
+
+**Parameters**
+
+| Parameter | Type     | Default | Description                               |
+| --------- | -------- | ------- | ----------------------------------------- |
+| `value`   | `number` | —       | The single-precision number to write.     |
+| `offset?` | `number` | —       | Byte offset to write to; defaults to `0`. |
+
+**Returns** `number` — `offset + 4`, the offset immediately following the written value.
+
+#### `writeInt16BE(value: number, offset?: number): number`
+
+Write a signed 16-bit big-endian integer at `offset`.
+
+**Parameters**
+
+| Parameter | Type     | Default | Description                               |
+| --------- | -------- | ------- | ----------------------------------------- |
+| `value`   | `number` | —       | The signed integer to write.              |
+| `offset?` | `number` | —       | Byte offset to write to; defaults to `0`. |
+
+**Returns** `number` — `offset + 2`, the offset immediately following the written value.
+
+#### `writeInt16LE(value: number, offset?: number): number`
+
+Write a signed 16-bit little-endian integer at `offset`.
+
+**Parameters**
+
+| Parameter | Type     | Default | Description                               |
+| --------- | -------- | ------- | ----------------------------------------- |
+| `value`   | `number` | —       | The signed integer to write.              |
+| `offset?` | `number` | —       | Byte offset to write to; defaults to `0`. |
+
+**Returns** `number` — `offset + 2`, the offset immediately following the written value.
+
+#### `writeInt32BE(value: number, offset?: number): number`
+
+Write a signed 32-bit big-endian integer at `offset`.
+
+**Parameters**
+
+| Parameter | Type     | Default | Description                               |
+| --------- | -------- | ------- | ----------------------------------------- |
+| `value`   | `number` | —       | The signed integer to write.              |
+| `offset?` | `number` | —       | Byte offset to write to; defaults to `0`. |
+
+**Returns** `number` — `offset + 4`, the offset immediately following the written value.
+
+#### `writeInt32LE(value: number, offset?: number): number`
+
+Write a signed 32-bit little-endian integer at `offset`.
+
+**Parameters**
+
+| Parameter | Type     | Default | Description                               |
+| --------- | -------- | ------- | ----------------------------------------- |
+| `value`   | `number` | —       | The signed integer to write.              |
+| `offset?` | `number` | —       | Byte offset to write to; defaults to `0`. |
+
+**Returns** `number` — `offset + 4`, the offset immediately following the written value.
+
+#### `writeInt8(value: number, offset?: number): number`
+
+Write a signed 8-bit integer at `offset`.
+
+**Parameters**
+
+| Parameter | Type     | Default | Description                               |
+| --------- | -------- | ------- | ----------------------------------------- |
+| `value`   | `number` | —       | The signed integer to write.              |
+| `offset?` | `number` | —       | Byte offset to write to; defaults to `0`. |
+
+**Returns** `number` — `offset + 1`, the offset immediately following the written value.
+
+#### `writeIntBE(value: number, offset: number, byteLength: number): number`
+
+Write a signed, big-endian, `byteLength`-byte integer at `offset`.
+
+**Parameters**
+
+| Parameter    | Type     | Default | Description                                |
+| ------------ | -------- | ------- | ------------------------------------------ |
+| `value`      | `number` | —       | The signed integer to write.               |
+| `offset`     | `number` | —       | Byte offset to write to.                   |
+| `byteLength` | `number` | —       | Number of bytes to write, from `1` to `6`. |
+
+**Returns** `number` — `offset + byteLength`, the offset immediately following the written value.
+
+**Throws**
+
+- `RangeError` — thrown if `byteLength` is not between `1` and `6`.
+
+#### `writeIntLE(value: number, offset: number, byteLength: number): number`
+
+Write a signed, little-endian, `byteLength`-byte integer at `offset`.
+
+**Parameters**
+
+| Parameter    | Type     | Default | Description                                |
+| ------------ | -------- | ------- | ------------------------------------------ |
+| `value`      | `number` | —       | The signed integer to write.               |
+| `offset`     | `number` | —       | Byte offset to write to.                   |
+| `byteLength` | `number` | —       | Number of bytes to write, from `1` to `6`. |
+
+**Returns** `number` — `offset + byteLength`, the offset immediately following the written value.
+
+**Throws**
+
+- `RangeError` — thrown if `byteLength` is not between `1` and `6`.
+
+#### `writeUint16BE(value: number, offset?: number): number`
+
+Write an unsigned 16-bit big-endian integer at `offset`.
+
+**Parameters**
+
+| Parameter | Type     | Default | Description                               |
+| --------- | -------- | ------- | ----------------------------------------- |
+| `value`   | `number` | —       | The unsigned integer to write.            |
+| `offset?` | `number` | —       | Byte offset to write to; defaults to `0`. |
+
+**Returns** `number` — `offset + 2`, the offset immediately following the written value.
+
+#### `writeUInt16BE(value: number, offset?: number): number`
+
+Write an unsigned 16-bit big-endian integer at `offset`.
+
+**Parameters**
+
+| Parameter | Type     | Default | Description                               |
+| --------- | -------- | ------- | ----------------------------------------- |
+| `value`   | `number` | —       | The unsigned integer to write.            |
+| `offset?` | `number` | —       | Byte offset to write to; defaults to `0`. |
+
+**Returns** `number` — `offset + 2`, the offset immediately following the written value.
+
+#### `writeUint16LE(value: number, offset?: number): number`
+
+Write an unsigned 16-bit little-endian integer at `offset`.
+
+**Parameters**
+
+| Parameter | Type     | Default | Description                               |
+| --------- | -------- | ------- | ----------------------------------------- |
+| `value`   | `number` | —       | The unsigned integer to write.            |
+| `offset?` | `number` | —       | Byte offset to write to; defaults to `0`. |
+
+**Returns** `number` — `offset + 2`, the offset immediately following the written value.
+
+#### `writeUInt16LE(value: number, offset?: number): number`
+
+Write an unsigned 16-bit little-endian integer at `offset`.
+
+**Parameters**
+
+| Parameter | Type     | Default | Description                               |
+| --------- | -------- | ------- | ----------------------------------------- |
+| `value`   | `number` | —       | The unsigned integer to write.            |
+| `offset?` | `number` | —       | Byte offset to write to; defaults to `0`. |
+
+**Returns** `number` — `offset + 2`, the offset immediately following the written value.
+
+#### `writeUint32BE(value: number, offset?: number): number`
+
+Write an unsigned 32-bit big-endian integer at `offset`.
+
+**Parameters**
+
+| Parameter | Type     | Default | Description                               |
+| --------- | -------- | ------- | ----------------------------------------- |
+| `value`   | `number` | —       | The unsigned integer to write.            |
+| `offset?` | `number` | —       | Byte offset to write to; defaults to `0`. |
+
+**Returns** `number` — `offset + 4`, the offset immediately following the written value.
+
+#### `writeUInt32BE(value: number, offset?: number): number`
+
+Write an unsigned 32-bit big-endian integer at `offset`.
+
+**Parameters**
+
+| Parameter | Type     | Default | Description                               |
+| --------- | -------- | ------- | ----------------------------------------- |
+| `value`   | `number` | —       | The unsigned integer to write.            |
+| `offset?` | `number` | —       | Byte offset to write to; defaults to `0`. |
+
+**Returns** `number` — `offset + 4`, the offset immediately following the written value.
+
+#### `writeUint32LE(value: number, offset?: number): number`
+
+Write an unsigned 32-bit little-endian integer at `offset`.
+
+**Parameters**
+
+| Parameter | Type     | Default | Description                               |
+| --------- | -------- | ------- | ----------------------------------------- |
+| `value`   | `number` | —       | The unsigned integer to write.            |
+| `offset?` | `number` | —       | Byte offset to write to; defaults to `0`. |
+
+**Returns** `number` — `offset + 4`, the offset immediately following the written value.
+
+#### `writeUInt32LE(value: number, offset?: number): number`
+
+Write an unsigned 32-bit little-endian integer at `offset`.
+
+**Parameters**
+
+| Parameter | Type     | Default | Description                               |
+| --------- | -------- | ------- | ----------------------------------------- |
+| `value`   | `number` | —       | The unsigned integer to write.            |
+| `offset?` | `number` | —       | Byte offset to write to; defaults to `0`. |
+
+**Returns** `number` — `offset + 4`, the offset immediately following the written value.
+
+#### `writeUint8(value: number, offset?: number): number`
+
+Write an unsigned 8-bit integer at `offset`.
+
+**Parameters**
+
+| Parameter | Type     | Default | Description                               |
+| --------- | -------- | ------- | ----------------------------------------- |
+| `value`   | `number` | —       | The unsigned integer to write.            |
+| `offset?` | `number` | —       | Byte offset to write to; defaults to `0`. |
+
+**Returns** `number` — `offset + 1`, the offset immediately following the written value.
+
+#### `writeUInt8(value: number, offset?: number): number`
+
+Write an unsigned 8-bit integer at `offset`.
+
+**Parameters**
+
+| Parameter | Type     | Default | Description                               |
+| --------- | -------- | ------- | ----------------------------------------- |
+| `value`   | `number` | —       | The unsigned integer to write.            |
+| `offset?` | `number` | —       | Byte offset to write to; defaults to `0`. |
+
+**Returns** `number` — `offset + 1`, the offset immediately following the written value.
+
+#### `writeUintBE(value: number, offset: number, byteLength: number): number`
+
+Write an unsigned, big-endian, `byteLength`-byte integer at `offset`.
+
+**Parameters**
+
+| Parameter    | Type     | Default | Description                                |
+| ------------ | -------- | ------- | ------------------------------------------ |
+| `value`      | `number` | —       | The unsigned integer to write.             |
+| `offset`     | `number` | —       | Byte offset to write to.                   |
+| `byteLength` | `number` | —       | Number of bytes to write, from `1` to `6`. |
+
+**Returns** `number` — `offset + byteLength`, the offset immediately following the written value.
+
+**Throws**
+
+- `RangeError` — thrown if `byteLength` is not between `1` and `6`.
+
+#### `writeUIntBE(value: number, offset: number, byteLength: number): number`
+
+Write an unsigned, big-endian, `byteLength`-byte integer at `offset`.
+
+**Parameters**
+
+| Parameter    | Type     | Default | Description                                |
+| ------------ | -------- | ------- | ------------------------------------------ |
+| `value`      | `number` | —       | The unsigned integer to write.             |
+| `offset`     | `number` | —       | Byte offset to write to.                   |
+| `byteLength` | `number` | —       | Number of bytes to write, from `1` to `6`. |
+
+**Returns** `number` — `offset + byteLength`, the offset immediately following the written value.
+
+**Throws**
+
+- `RangeError` — thrown if `byteLength` is not between `1` and `6`.
+
+#### `writeUintLE(value: number, offset: number, byteLength: number): number`
+
+Write an unsigned, little-endian, `byteLength`-byte integer at `offset`.
+
+**Parameters**
+
+| Parameter    | Type     | Default | Description                                |
+| ------------ | -------- | ------- | ------------------------------------------ |
+| `value`      | `number` | —       | The unsigned integer to write.             |
+| `offset`     | `number` | —       | Byte offset to write to.                   |
+| `byteLength` | `number` | —       | Number of bytes to write, from `1` to `6`. |
+
+**Returns** `number` — `offset + byteLength`, the offset immediately following the written value.
+
+**Throws**
+
+- `RangeError` — thrown if `byteLength` is not between `1` and `6`.
+
+#### `writeUIntLE(value: number, offset: number, byteLength: number): number`
+
+Write an unsigned, little-endian, `byteLength`-byte integer at `offset`.
+
+**Parameters**
+
+| Parameter    | Type     | Default | Description                                |
+| ------------ | -------- | ------- | ------------------------------------------ |
+| `value`      | `number` | —       | The unsigned integer to write.             |
+| `offset`     | `number` | —       | Byte offset to write to.                   |
+| `byteLength` | `number` | —       | Number of bytes to write, from `1` to `6`. |
+
+**Returns** `number` — `offset + byteLength`, the offset immediately following the written value.
+
+**Throws**
+
+- `RangeError` — thrown if `byteLength` is not between `1` and `6`.
+
+## `bare-buffer/global`
+
+### Types
+
+#### `BufferConstructor`
+
+```ts
+type BufferConstructor = typeof buffer.Buffer
+```
+
+## `bare-buffer/constants`
+
+### Constants and variables
+
+#### `constants: { MAX_LENGTH: number; MAX_STRING_LENGTH: number }`
+
+Limits for buffers and strings: `MAX_LENGTH` (largest possible `Buffer`) and `MAX_STRING_LENGTH` (largest possible string).
+<!-- bare-refgen:api end -->

--- a/global.d.ts
+++ b/global.d.ts
@@ -3,10 +3,19 @@ import * as buffer from '.'
 type BufferConstructor = typeof buffer.Buffer
 
 declare global {
+  /** A fixed-length view of binary data, backed by an `ArrayBuffer` and extending `Uint8Array`. */
   type Buffer = buffer.Buffer
 
   const Buffer: BufferConstructor
 
+  /**
+   * Decode a base64-encoded string into a Latin-1 binary string.
+   * @param data - The base64-encoded string to decode.
+   */
   const atob: typeof buffer.atob
+  /**
+   * Encode a Latin-1 binary string into a base64 string.
+   * @param data - The value to encode; non-strings are coerced with `String()`.
+   */
   const btoa: typeof buffer.btoa
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,6 @@
 import constants from './lib/constants'
 
+/** The set of encodings supported by `Buffer` methods that convert between bytes and strings. */
 type BufferEncoding =
   | 'ascii'
   | 'base64'
@@ -14,6 +15,16 @@ type BufferEncoding =
   | 'utf8'
 
 interface Buffer extends Uint8Array<ArrayBuffer> {
+  /**
+   * Compare two buffers' contents lexicographically, returning -1, 0, or 1 for sort ordering.
+   * @param a - The first buffer to compare.
+   * @param b - The second buffer to compare.
+   * @param target - The buffer to compare against.
+   * @param targetStart - Offset within `target` to start comparing from; defaults to `0`.
+   * @param targetEnd - Offset within `target` (exclusive) to stop comparing at; defaults to `target.byteLength`.
+   * @param sourceStart - Offset within this buffer to start comparing from; defaults to `0`.
+   * @param sourceEnd - Offset within this buffer (exclusive) to stop comparing at; defaults to `this.byteLength`.
+   */
   compare(
     target: Buffer,
     targetStart?: number,
@@ -22,150 +33,601 @@ interface Buffer extends Uint8Array<ArrayBuffer> {
     sourceEnd?: number
   ): number
 
+  /**
+   * Copy bytes from this buffer into `target`, returning the number of bytes copied.
+   * @param target - The buffer to copy into.
+   * @param targetStart - Offset within `target` to start writing at; defaults to `0`.
+   * @param sourceStart - Offset within this buffer to start copying from; defaults to `0`.
+   * @param sourceEnd - Offset within this buffer (exclusive) to stop copying at; defaults to `this.byteLength`.
+   */
   copy(target: Buffer, targetStart?: number, sourceStart?: number, sourceEnd?: number): number
 
+  /**
+   * Check whether this buffer and `target` have identical contents.
+   * @param target - The buffer to compare this buffer's contents against.
+   */
   equals(target: Buffer): boolean
 
+  /**
+   * Fill this buffer with `value`, repeating as needed, and return it.
+   * @param value - The value to fill with — a string (repeated across the range), or a `Buffer`/number/boolean byte.
+   * @param encoding - Encoding used to interpret `value` when it's a string; defaults to `'utf8'`.
+   * @throws {Error} thrown if the encoding is not a recognized `BufferEncoding`.
+   */
   fill(value: string, encoding?: BufferEncoding): this
   fill(value: string, offset?: number, encoding?: BufferEncoding): this
   fill(value: string, offset?: number, end?: number, encoding?: BufferEncoding): this
   fill(value: Buffer | number | boolean, offset?: number, end?: number): this
 
+  /**
+   * Check whether this buffer contains `value`.
+   * @param value - The value to search for — a string, `Buffer`, number byte, or boolean.
+   * @param encoding - Encoding used to interpret `value` when it's a string; defaults to `'utf8'`.
+   * @throws {Error} thrown if the encoding is not a recognized `BufferEncoding`.
+   */
   includes(value: string, encoding?: BufferEncoding): boolean
   includes(value: string, offset?: number, encoding?: BufferEncoding): boolean
   includes(value: Buffer | number | boolean, offset?: number): boolean
 
+  /**
+   * Return the first index at which `value` occurs in this buffer, or `-1` if not found.
+   * @param value - The value to search for — a string, `Buffer`, number byte, or boolean.
+   * @param encoding - Encoding used to interpret `value` when it's a string; defaults to `'utf8'`.
+   * @throws {Error} thrown if the encoding is not a recognized `BufferEncoding`.
+   */
   indexOf(value: string, encoding?: BufferEncoding): number
   indexOf(value: string, offset?: number, encoding?: BufferEncoding): number
   indexOf(value: Buffer | number | boolean, offset?: number): number
 
+  /**
+   * Return the last index at which `value` occurs in this buffer, or `-1` if not found.
+   * @param value - The value to search for — a string, `Buffer`, number byte, or boolean.
+   * @param encoding - Encoding used to interpret `value` when it's a string; defaults to `'utf8'`.
+   * @throws {Error} thrown if the encoding is not a recognized `BufferEncoding`.
+   */
   lastIndexOf(value: string, encoding?: BufferEncoding): number
   lastIndexOf(value: string, offset?: number, encoding?: BufferEncoding): number
   lastIndexOf(value: Buffer | number | boolean, offset?: number): number
 
+  /**
+   * Swap the byte order of each 16-bit group in this buffer in place, and return it.
+   * @throws {RangeError} thrown if the buffer's length is not a multiple of 2 bytes.
+   */
   swap16(): this
+  /**
+   * Swap the byte order of each 32-bit group in this buffer in place, and return it.
+   * @throws {RangeError} thrown if the buffer's length is not a multiple of 4 bytes.
+   */
   swap32(): this
+  /**
+   * Swap the byte order of each 64-bit group in this buffer in place, and return it.
+   * @throws {RangeError} thrown if the buffer's length is not a multiple of 8 bytes.
+   */
   swap64(): this
 
+  /**
+   * Decode this buffer (or a slice of it) to a string using `encoding`.
+   * @param encoding - Encoding used to decode the bytes; defaults to `'utf8'`.
+   * @param start - Byte offset to start decoding from; defaults to `0`.
+   * @param end - Byte offset (exclusive) to stop decoding at; defaults to `this.byteLength`.
+   * @throws {Error} thrown if the encoding is not a recognized `BufferEncoding`.
+   */
   toString(encoding?: BufferEncoding, start?: number, end?: number): string
 
+  /** Return an array of this buffer's bytes, used when the buffer is passed to `JSON.stringify()`. */
   toJSON(): number[]
 
+  /**
+   * Read a 64-bit big-endian double at `offset`.
+   * @param offset - Byte offset to read from; defaults to `0`.
+   */
   readDoubleBE(offset?: number): number
+  /**
+   * Read a 64-bit little-endian double at `offset`.
+   * @param offset - Byte offset to read from; defaults to `0`.
+   */
   readDoubleLE(offset?: number): number
 
+  /**
+   * Read a 32-bit big-endian float at `offset`.
+   * @param offset - Byte offset to read from; defaults to `0`.
+   */
   readFloatBE(offset?: number): number
+  /**
+   * Read a 32-bit little-endian float at `offset`.
+   * @param offset - Byte offset to read from; defaults to `0`.
+   */
   readFloatLE(offset?: number): number
 
+  /**
+   * Read a signed 8-bit integer at `offset`.
+   * @param offset - Byte offset to read from; defaults to `0`.
+   */
   readInt8(offset?: number): number
 
+  /**
+   * Read a signed 16-bit big-endian integer at `offset`.
+   * @param offset - Byte offset to read from; defaults to `0`.
+   */
   readInt16BE(offset?: number): number
+  /**
+   * Read a signed 16-bit little-endian integer at `offset`.
+   * @param offset - Byte offset to read from; defaults to `0`.
+   */
   readInt16LE(offset?: number): number
 
+  /**
+   * Read a signed 32-bit big-endian integer at `offset`.
+   * @param offset - Byte offset to read from; defaults to `0`.
+   */
   readInt32BE(offset?: number): number
+  /**
+   * Read a signed 32-bit little-endian integer at `offset`.
+   * @param offset - Byte offset to read from; defaults to `0`.
+   */
   readInt32LE(offset?: number): number
 
+  /**
+   * Read a signed, big-endian, `byteLength`-byte integer at `offset`.
+   * @param offset - Byte offset to read from.
+   * @param byteLength - Number of bytes to read, from `1` to `6`.
+   * @throws {RangeError} thrown if `byteLength` is not between `1` and `6`.
+   */
   readIntBE(offset: number, byteLength: number): number
+  /**
+   * Read a signed, little-endian, `byteLength`-byte integer at `offset`.
+   * @param offset - Byte offset to read from.
+   * @param byteLength - Number of bytes to read, from `1` to `6`.
+   * @throws {RangeError} thrown if `byteLength` is not between `1` and `6`.
+   */
   readIntLE(offset: number, byteLength: number): number
 
+  /**
+   * Read a signed 64-bit big-endian integer at `offset`.
+   * @param offset - Byte offset to read from; defaults to `0`.
+   */
   readBigInt64BE(offset?: number): bigint
+  /**
+   * Read a signed 64-bit little-endian integer at `offset`.
+   * @param offset - Byte offset to read from; defaults to `0`.
+   */
   readBigInt64LE(offset?: number): bigint
 
+  /**
+   * Read an unsigned 8-bit integer at `offset`.
+   * @param offset - Byte offset to read from; defaults to `0`.
+   */
   readUInt8(offset?: number): number
+  /**
+   * Read an unsigned 8-bit integer at `offset`.
+   * @param offset - Byte offset to read from; defaults to `0`.
+   */
   readUint8(offset?: number): number
 
+  /**
+   * Read an unsigned 16-bit big-endian integer at `offset`.
+   * @param offset - Byte offset to read from; defaults to `0`.
+   */
   readUInt16BE(offset?: number): number
+  /**
+   * Read an unsigned 16-bit big-endian integer at `offset`.
+   * @param offset - Byte offset to read from; defaults to `0`.
+   */
   readUint16BE(offset?: number): number
+  /**
+   * Read an unsigned 16-bit little-endian integer at `offset`.
+   * @param offset - Byte offset to read from; defaults to `0`.
+   */
   readUInt16LE(offset?: number): number
+  /**
+   * Read an unsigned 16-bit little-endian integer at `offset`.
+   * @param offset - Byte offset to read from; defaults to `0`.
+   */
   readUint16LE(offset?: number): number
 
+  /**
+   * Read an unsigned 32-bit big-endian integer at `offset`.
+   * @param offset - Byte offset to read from; defaults to `0`.
+   */
   readUInt32BE(offset?: number): number
+  /**
+   * Read an unsigned 32-bit big-endian integer at `offset`.
+   * @param offset - Byte offset to read from; defaults to `0`.
+   */
   readUint32BE(offset?: number): number
+  /**
+   * Read an unsigned 32-bit little-endian integer at `offset`.
+   * @param offset - Byte offset to read from; defaults to `0`.
+   */
   readUInt32LE(offset?: number): number
+  /**
+   * Read an unsigned 32-bit little-endian integer at `offset`.
+   * @param offset - Byte offset to read from; defaults to `0`.
+   */
   readUint32LE(offset?: number): number
 
+  /**
+   * Read an unsigned, big-endian, `byteLength`-byte integer at `offset`.
+   * @param offset - Byte offset to read from.
+   * @param byteLength - Number of bytes to read, from `1` to `6`.
+   * @throws {RangeError} thrown if `byteLength` is not between `1` and `6`.
+   */
   readUIntBE(offset: number, byteLength: number): number
+  /**
+   * Read an unsigned, big-endian, `byteLength`-byte integer at `offset`.
+   * @param offset - Byte offset to read from.
+   * @param byteLength - Number of bytes to read, from `1` to `6`.
+   * @throws {RangeError} thrown if `byteLength` is not between `1` and `6`.
+   */
   readUintBE(offset: number, byteLength: number): number
+  /**
+   * Read an unsigned, little-endian, `byteLength`-byte integer at `offset`.
+   * @param offset - Byte offset to read from.
+   * @param byteLength - Number of bytes to read, from `1` to `6`.
+   * @throws {RangeError} thrown if `byteLength` is not between `1` and `6`.
+   */
   readUIntLE(offset: number, byteLength: number): number
+  /**
+   * Read an unsigned, little-endian, `byteLength`-byte integer at `offset`.
+   * @param offset - Byte offset to read from.
+   * @param byteLength - Number of bytes to read, from `1` to `6`.
+   * @throws {RangeError} thrown if `byteLength` is not between `1` and `6`.
+   */
   readUintLE(offset: number, byteLength: number): number
 
+  /**
+   * Read an unsigned 64-bit big-endian integer at `offset`.
+   * @param offset - Byte offset to read from; defaults to `0`.
+   */
   readBigUInt64BE(offset?: number): bigint
+  /**
+   * Read an unsigned 64-bit big-endian integer at `offset`.
+   * @param offset - Byte offset to read from; defaults to `0`.
+   */
   readBigUint64BE(offset?: number): bigint
+  /**
+   * Read an unsigned 64-bit little-endian integer at `offset`.
+   * @param offset - Byte offset to read from; defaults to `0`.
+   */
   readBigUInt64LE(offset?: number): bigint
+  /**
+   * Read an unsigned 64-bit little-endian integer at `offset`.
+   * @param offset - Byte offset to read from; defaults to `0`.
+   */
   readBigUint64LE(offset?: number): bigint
 
+  /**
+   * Write `string` into this buffer using `encoding`, returning the number of bytes written.
+   * @param string - The string to write.
+   * @param encoding - Encoding used to encode `string`; defaults to `'utf8'`.
+   * @throws {Error} thrown if the encoding is not a recognized `BufferEncoding`.
+   */
   write(string: string, encoding?: BufferEncoding): number
   write(string: string, offset?: number, encoding?: BufferEncoding): number
   write(string: string, offset?: number, length?: number, encoding?: BufferEncoding): number
 
+  /**
+   * Write a 64-bit big-endian double at `offset`.
+   * @param value - The double-precision number to write.
+   * @param offset - Byte offset to write to; defaults to `0`.
+   * @returns `offset + 8`, the offset immediately following the written value.
+   */
   writeDoubleBE(value: number, offset?: number): number
+  /**
+   * Write a 64-bit little-endian double at `offset`.
+   * @param value - The double-precision number to write.
+   * @param offset - Byte offset to write to; defaults to `0`.
+   * @returns `offset + 8`, the offset immediately following the written value.
+   */
   writeDoubleLE(value: number, offset?: number): number
 
+  /**
+   * Write a 32-bit big-endian float at `offset`.
+   * @param value - The single-precision number to write.
+   * @param offset - Byte offset to write to; defaults to `0`.
+   * @returns `offset + 4`, the offset immediately following the written value.
+   */
   writeFloatBE(value: number, offset?: number): number
+  /**
+   * Write a 32-bit little-endian float at `offset`.
+   * @param value - The single-precision number to write.
+   * @param offset - Byte offset to write to; defaults to `0`.
+   * @returns `offset + 4`, the offset immediately following the written value.
+   */
   writeFloatLE(value: number, offset?: number): number
 
+  /**
+   * Write a signed 8-bit integer at `offset`.
+   * @param value - The signed integer to write.
+   * @param offset - Byte offset to write to; defaults to `0`.
+   * @returns `offset + 1`, the offset immediately following the written value.
+   */
   writeInt8(value: number, offset?: number): number
 
+  /**
+   * Write a signed 16-bit big-endian integer at `offset`.
+   * @param value - The signed integer to write.
+   * @param offset - Byte offset to write to; defaults to `0`.
+   * @returns `offset + 2`, the offset immediately following the written value.
+   */
   writeInt16BE(value: number, offset?: number): number
+  /**
+   * Write a signed 16-bit little-endian integer at `offset`.
+   * @param value - The signed integer to write.
+   * @param offset - Byte offset to write to; defaults to `0`.
+   * @returns `offset + 2`, the offset immediately following the written value.
+   */
   writeInt16LE(value: number, offset?: number): number
 
+  /**
+   * Write a signed 32-bit big-endian integer at `offset`.
+   * @param value - The signed integer to write.
+   * @param offset - Byte offset to write to; defaults to `0`.
+   * @returns `offset + 4`, the offset immediately following the written value.
+   */
   writeInt32BE(value: number, offset?: number): number
+  /**
+   * Write a signed 32-bit little-endian integer at `offset`.
+   * @param value - The signed integer to write.
+   * @param offset - Byte offset to write to; defaults to `0`.
+   * @returns `offset + 4`, the offset immediately following the written value.
+   */
   writeInt32LE(value: number, offset?: number): number
 
+  /**
+   * Write a signed, big-endian, `byteLength`-byte integer at `offset`.
+   * @param value - The signed integer to write.
+   * @param offset - Byte offset to write to.
+   * @param byteLength - Number of bytes to write, from `1` to `6`.
+   * @returns `offset + byteLength`, the offset immediately following the written value.
+   * @throws {RangeError} thrown if `byteLength` is not between `1` and `6`.
+   */
   writeIntBE(value: number, offset: number, byteLength: number): number
+  /**
+   * Write a signed, little-endian, `byteLength`-byte integer at `offset`.
+   * @param value - The signed integer to write.
+   * @param offset - Byte offset to write to.
+   * @param byteLength - Number of bytes to write, from `1` to `6`.
+   * @returns `offset + byteLength`, the offset immediately following the written value.
+   * @throws {RangeError} thrown if `byteLength` is not between `1` and `6`.
+   */
   writeIntLE(value: number, offset: number, byteLength: number): number
 
+  /**
+   * Write a signed 64-bit big-endian integer at `offset`.
+   * @param value - The signed `bigint` to write.
+   * @param offset - Byte offset to write to; defaults to `0`.
+   * @returns `offset + 8`, the offset immediately following the written value.
+   */
   writeBigInt64BE(value: bigint, offset?: number): number
+  /**
+   * Write a signed 64-bit little-endian integer at `offset`.
+   * @param value - The signed `bigint` to write.
+   * @param offset - Byte offset to write to; defaults to `0`.
+   * @returns `offset + 8`, the offset immediately following the written value.
+   */
   writeBigInt64LE(value: bigint, offset?: number): number
 
+  /**
+   * Write an unsigned 8-bit integer at `offset`.
+   * @param value - The unsigned integer to write.
+   * @param offset - Byte offset to write to; defaults to `0`.
+   * @returns `offset + 1`, the offset immediately following the written value.
+   */
   writeUInt8(value: number, offset?: number): number
+  /**
+   * Write an unsigned 8-bit integer at `offset`.
+   * @param value - The unsigned integer to write.
+   * @param offset - Byte offset to write to; defaults to `0`.
+   * @returns `offset + 1`, the offset immediately following the written value.
+   */
   writeUint8(value: number, offset?: number): number
 
+  /**
+   * Write an unsigned 16-bit big-endian integer at `offset`.
+   * @param value - The unsigned integer to write.
+   * @param offset - Byte offset to write to; defaults to `0`.
+   * @returns `offset + 2`, the offset immediately following the written value.
+   */
   writeUInt16BE(value: number, offset?: number): number
+  /**
+   * Write an unsigned 16-bit big-endian integer at `offset`.
+   * @param value - The unsigned integer to write.
+   * @param offset - Byte offset to write to; defaults to `0`.
+   * @returns `offset + 2`, the offset immediately following the written value.
+   */
   writeUint16BE(value: number, offset?: number): number
+  /**
+   * Write an unsigned 16-bit little-endian integer at `offset`.
+   * @param value - The unsigned integer to write.
+   * @param offset - Byte offset to write to; defaults to `0`.
+   * @returns `offset + 2`, the offset immediately following the written value.
+   */
   writeUInt16LE(value: number, offset?: number): number
+  /**
+   * Write an unsigned 16-bit little-endian integer at `offset`.
+   * @param value - The unsigned integer to write.
+   * @param offset - Byte offset to write to; defaults to `0`.
+   * @returns `offset + 2`, the offset immediately following the written value.
+   */
   writeUint16LE(value: number, offset?: number): number
 
+  /**
+   * Write an unsigned 32-bit big-endian integer at `offset`.
+   * @param value - The unsigned integer to write.
+   * @param offset - Byte offset to write to; defaults to `0`.
+   * @returns `offset + 4`, the offset immediately following the written value.
+   */
   writeUInt32BE(value: number, offset?: number): number
+  /**
+   * Write an unsigned 32-bit big-endian integer at `offset`.
+   * @param value - The unsigned integer to write.
+   * @param offset - Byte offset to write to; defaults to `0`.
+   * @returns `offset + 4`, the offset immediately following the written value.
+   */
   writeUint32BE(value: number, offset?: number): number
+  /**
+   * Write an unsigned 32-bit little-endian integer at `offset`.
+   * @param value - The unsigned integer to write.
+   * @param offset - Byte offset to write to; defaults to `0`.
+   * @returns `offset + 4`, the offset immediately following the written value.
+   */
   writeUInt32LE(value: number, offset?: number): number
+  /**
+   * Write an unsigned 32-bit little-endian integer at `offset`.
+   * @param value - The unsigned integer to write.
+   * @param offset - Byte offset to write to; defaults to `0`.
+   * @returns `offset + 4`, the offset immediately following the written value.
+   */
   writeUint32LE(value: number, offset?: number): number
 
+  /**
+   * Write an unsigned, big-endian, `byteLength`-byte integer at `offset`.
+   * @param value - The unsigned integer to write.
+   * @param offset - Byte offset to write to.
+   * @param byteLength - Number of bytes to write, from `1` to `6`.
+   * @returns `offset + byteLength`, the offset immediately following the written value.
+   * @throws {RangeError} thrown if `byteLength` is not between `1` and `6`.
+   */
   writeUIntBE(value: number, offset: number, byteLength: number): number
+  /**
+   * Write an unsigned, big-endian, `byteLength`-byte integer at `offset`.
+   * @param value - The unsigned integer to write.
+   * @param offset - Byte offset to write to.
+   * @param byteLength - Number of bytes to write, from `1` to `6`.
+   * @returns `offset + byteLength`, the offset immediately following the written value.
+   * @throws {RangeError} thrown if `byteLength` is not between `1` and `6`.
+   */
   writeUintBE(value: number, offset: number, byteLength: number): number
+  /**
+   * Write an unsigned, little-endian, `byteLength`-byte integer at `offset`.
+   * @param value - The unsigned integer to write.
+   * @param offset - Byte offset to write to.
+   * @param byteLength - Number of bytes to write, from `1` to `6`.
+   * @returns `offset + byteLength`, the offset immediately following the written value.
+   * @throws {RangeError} thrown if `byteLength` is not between `1` and `6`.
+   */
   writeUIntLE(value: number, offset: number, byteLength: number): number
+  /**
+   * Write an unsigned, little-endian, `byteLength`-byte integer at `offset`.
+   * @param value - The unsigned integer to write.
+   * @param offset - Byte offset to write to.
+   * @param byteLength - Number of bytes to write, from `1` to `6`.
+   * @returns `offset + byteLength`, the offset immediately following the written value.
+   * @throws {RangeError} thrown if `byteLength` is not between `1` and `6`.
+   */
   writeUintLE(value: number, offset: number, byteLength: number): number
 
+  /**
+   * Write an unsigned 64-bit big-endian integer at `offset`.
+   * @param value - The unsigned `bigint` to write.
+   * @param offset - Byte offset to write to; defaults to `0`.
+   * @returns `offset + 8`, the offset immediately following the written value.
+   */
   writeBigUint64BE(value: bigint, offset?: number): number
+  /**
+   * Write an unsigned 64-bit big-endian integer at `offset`.
+   * @param value - The unsigned `bigint` to write.
+   * @param offset - Byte offset to write to; defaults to `0`.
+   * @returns `offset + 8`, the offset immediately following the written value.
+   */
   writeBigUInt64BE(value: bigint, offset?: number): number
+  /**
+   * Write an unsigned 64-bit little-endian integer at `offset`.
+   * @param value - The unsigned `bigint` to write.
+   * @param offset - Byte offset to write to; defaults to `0`.
+   * @returns `offset + 8`, the offset immediately following the written value.
+   */
   writeBigUint64LE(value: bigint, offset?: number): number
+  /**
+   * Write an unsigned 64-bit little-endian integer at `offset`.
+   * @param value - The unsigned `bigint` to write.
+   * @param offset - Byte offset to write to; defaults to `0`.
+   * @returns `offset + 8`, the offset immediately following the written value.
+   */
   writeBigUInt64LE(value: bigint, offset?: number): number
 }
 
 declare class Buffer extends Uint8Array<ArrayBuffer> {
+  /**
+   * Create a `Buffer` viewing `arrayBuffer`, optionally starting at `offset` for `length` bytes.
+   * @param arrayBuffer - The `ArrayBuffer` to view.
+   * @param offset - Byte offset into `arrayBuffer` to start the view at; defaults to `0`.
+   * @param length - Number of bytes to view from `offset`; defaults to the rest of `arrayBuffer`.
+   * @throws {RangeError} thrown if the resulting length would exceed `Buffer.constants.MAX_LENGTH`.
+   */
   constructor(arrayBuffer: ArrayBuffer, offset?: number, length?: number)
 }
 
+/** A fixed-length view of binary data, backed by an `ArrayBuffer` and extending `Uint8Array`. */
 declare namespace Buffer {
+  /** The size, in bytes, of the internal buffer pool used to satisfy small allocations. */
   export let poolSize: number
 
+  /**
+   * Check whether `value` is a `Buffer`.
+   * @param value - The value to check.
+   */
   export function isBuffer(value: unknown): value is Buffer
 
+  /**
+   * Check whether `encoding` is a supported `BufferEncoding`.
+   * @param encoding - The encoding name to check.
+   */
   export function isEncoding(encoding: string): encoding is BufferEncoding
 
+  /**
+   * Check whether `buffer` contains only valid ASCII-encoded data.
+   * @param buffer - The buffer to check.
+   */
   export function isASCII(buffer: Buffer): boolean
+  /**
+   * Check whether `buffer` contains only valid ASCII-encoded data.
+   * @param buffer - The buffer to check.
+   */
   export function isAscii(buffer: Buffer): boolean
 
+  /**
+   * Check whether `buffer` contains only valid UTF-8-encoded data.
+   * @param buffer - The buffer to check.
+   */
   export function isUTF8(buffer: Buffer): boolean
+  /**
+   * Check whether `buffer` contains only valid UTF-8-encoded data.
+   * @param buffer - The buffer to check.
+   */
   export function isUtf8(buffer: Buffer): boolean
 
+  /**
+   * Allocate a new, zero-filled `Buffer` of `size` bytes, optionally filled with `fill`.
+   * @param size - Number of bytes to allocate.
+   * @param fill - Value to fill the buffer with — a string, `Buffer`, number byte, or boolean.
+   * @param encoding - Encoding used to interpret `fill` when it's a string; defaults to `'utf8'`.
+   * @throws {RangeError} thrown if `size` exceeds `Buffer.constants.MAX_LENGTH`.
+   */
   export function alloc(size: number, fill: string, encoding?: BufferEncoding): Buffer
   export function alloc(size: number, fill?: Buffer | number | boolean): Buffer
 
+  /**
+   * Allocate a new `Buffer` of `size` bytes without zeroing its contents first.
+   * @param size - Number of bytes to allocate.
+   * @throws {RangeError} thrown if `size` exceeds `Buffer.constants.MAX_LENGTH`.
+   */
   export function allocUnsafe(size: number): Buffer
 
+  /**
+   * Allocate a new `Buffer` of `size` bytes without zeroing its contents first, bypassing the internal buffer pool.
+   * @param size - Number of bytes to allocate.
+   * @throws {RangeError} thrown if `size` exceeds `Buffer.constants.MAX_LENGTH`.
+   */
   export function allocUnsafeSlow(size: number): Buffer
 
+  /**
+   * Return the number of bytes `string` would occupy once encoded as `encoding`.
+   * @param string - The value whose encoded length to measure — a string, or an `ArrayBufferView`/`ArrayBufferLike` (whose own `byteLength` is returned unchanged).
+   * @param encoding - Encoding used to measure `string` when it's a string; defaults to `'utf8'`.
+   * @throws {Error} thrown if the encoding is not a recognized `BufferEncoding`.
+   */
   export function byteLength(
     string: ArrayBufferView | ArrayBufferLike | string,
     encoding?: BufferEncoding
@@ -173,20 +635,56 @@ declare namespace Buffer {
 
   export function compare(a: Buffer, b: Buffer): number
 
+  /**
+   * Concatenate `buffers` into a single new `Buffer`, optionally truncated or zero-padded to `length`.
+   * @param buffers - The buffers to concatenate, in order.
+   * @param length - Total byte length of the result; defaults to the sum of `buffers`' lengths.
+   */
   export function concat(buffers: Buffer[], length?: number): Buffer
 
+  /**
+   * Return `buffer` unchanged if it is already a `Buffer`, otherwise wrap its underlying `ArrayBuffer` in a new `Buffer`.
+   * @param buffer - The value to coerce into a `Buffer`.
+   */
   export function coerce(buffer: Buffer): Buffer
 
+  /**
+   * Copy the bytes of `view`, starting at `offset` for `length` elements, into a new `Buffer`.
+   * @param view - The typed array (or other `ArrayBufferLike` view) to copy bytes from.
+   * @param offset - Index of the first element to copy; defaults to `0`.
+   * @param length - Number of elements to copy; defaults to the rest of `view`.
+   * @throws {RangeError} thrown if `offset + length` exceeds `view.length`.
+   */
   export function copyBytesFrom(view: ArrayBufferLike, offset?: number, length?: number): Buffer
 
+  /**
+   * Create a new `Buffer` from an array, array-like, string, or `ArrayBuffer`.
+   * @param data - The array, array-like, string, buffer, or `ArrayBuffer` to create a new `Buffer` from.
+   * @throws {Error} thrown if the encoding is not a recognized `BufferEncoding`.
+   */
   export function from(data: Iterable<number>): Buffer
   export function from(data: ArrayLike<number>): Buffer
   export function from(string: string, encoding?: BufferEncoding): Buffer
   export function from(arrayBuffer: ArrayBufferLike, offset?: number, length?: number): Buffer
 
+  /**
+   * Decode a base64-encoded string into a Latin-1 binary string.
+   * @param data - The base64-encoded string to decode.
+   */
   export function atob(data: unknown): string
+  /**
+   * Encode a Latin-1 binary string into a base64 string.
+   * @param data - The value to encode; non-strings are coerced with `String()`.
+   */
   export function btoa(data: unknown): string
 
+  /**
+   * Re-encode `buffer` from one encoding to another, returning a new `Buffer`.
+   * @param buffer - The buffer to re-encode.
+   * @param from - The encoding `buffer` is currently in.
+   * @param to - The encoding to convert to.
+   * @throws {Error} thrown if the encoding is not a recognized `BufferEncoding`.
+   */
   export function transcode(buffer: Buffer, from: BufferEncoding, to: BufferEncoding): Buffer
 
   export { Buffer, type BufferEncoding, constants }

--- a/lib/constants.d.ts
+++ b/lib/constants.d.ts
@@ -1,3 +1,4 @@
+/** Limits for buffers and strings: `MAX_LENGTH` (largest possible `Buffer`) and `MAX_STRING_LENGTH` (largest possible string). */
 declare const constants: { MAX_LENGTH: number; MAX_STRING_LENGTH: number }
 
 export = constants


### PR DESCRIPTION
## Document the public API as TSDoc

Adds TSDoc — `@param` / `@returns` / `@throws` tags plus member descriptions — to the shipped `.d.ts`, and regenerates the README `## API` section. Everything is derived from the existing type declarations and this module's own `index.js`/`lib` source; there are no AI-authored behavioral claims.

Produced by the [`pear-docs`](https://github.com/holepunchto/pear-docs) `bare-refgen` tooling, which documents the Bare module APIs from their type declarations. The README `## API` block is wrapped in `<!-- bare-refgen:api start/end -->` markers so it can be regenerated in place without disturbing surrounding prose.

Reviewed against source; happy to adjust wording, scope, or split as you prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
